### PR TITLE
Add basic voice-to-text script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,26 @@
 # My First Repo
 
 This is my very first GitHub repository!
+
+## Voice to Text Demo
+
+This repository now includes a small Python script [`voice_to_text.py`](voice_to_text.py) that listens to the microphone and prints the recognized speech.
+
+### Requirements
+
+- [SpeechRecognition](https://pypi.org/project/SpeechRecognition/)
+- [PyAudio](https://pypi.org/project/PyAudio/)
+
+Install them with:
+
+```
+pip install SpeechRecognition PyAudio
+```
+
+### Usage
+
+Run the script and speak into your microphone:
+
+```
+python voice_to_text.py
+```

--- a/voice_to_text.py
+++ b/voice_to_text.py
@@ -1,0 +1,22 @@
+import speech_recognition as sr
+
+
+def listen_and_transcribe() -> None:
+    """Listen to the microphone and print the recognized text."""
+    recognizer = sr.Recognizer()
+
+    with sr.Microphone() as source:
+        print("Please say something...")
+        audio = recognizer.listen(source)
+
+    try:
+        text = recognizer.recognize_google(audio)
+        print("You said:", text)
+    except sr.UnknownValueError:
+        print("Sorry, could not understand the audio.")
+    except sr.RequestError as exc:
+        print(f"Could not request results; {exc}")
+
+
+if __name__ == "__main__":
+    listen_and_transcribe()


### PR DESCRIPTION
## Summary
- add `voice_to_text.py` demo that records from the microphone and prints recognized speech
- document requirements and usage in `README.md`

## Testing
- `python voice_to_text.py` *(fails: ModuleNotFoundError: No module named 'speech_recognition')*

------
https://chatgpt.com/codex/tasks/task_e_68c5840cfbfc832c82dad86e3a0a6f26